### PR TITLE
CLK-1058 storing qsh verification result in request headers

### DIFF
--- a/lib/atlassian-jwt-authentication/middleware.rb
+++ b/lib/atlassian-jwt-authentication/middleware.rb
@@ -6,6 +6,7 @@ module AtlassianJwtAuthentication
       JWT_TOKEN_HEADER = "#{PREFIX}.jwt_token".freeze
       JWT_CONTEXT = "#{PREFIX}.context".freeze
       JWT_ACCOUNT_ID = "#{PREFIX}.account_id".freeze
+      JWT_QSH_VERIFIED = "#{PREFIX}.qsh_verified".freeze
 
       def initialize(app, addon_key)
         @app = app
@@ -23,7 +24,7 @@ module AtlassianJwtAuthentication
         end
 
         if jwt
-          jwt_auth, account_id, context = Verify.verify_jwt(@addon_key, jwt, request, [])
+          jwt_auth, account_id, context, qsh_verified = Verify.verify_jwt(@addon_key, jwt, request, [])
 
           if jwt_auth
             request.set_header(JWT_TOKEN_HEADER, jwt_auth)
@@ -35,6 +36,10 @@ module AtlassianJwtAuthentication
 
           if context
             request.set_header(JWT_CONTEXT, context)
+          end
+
+          if qsh_verified
+            request.set_header(JWT_QSH_VERIFIED, qsh_verified)
           end
         end
 

--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -89,6 +89,10 @@ module AtlassianJwtAuthentication
         unless data['qsh'] == qsh
           return false
         end
+
+        qsh_verified = true
+      else
+        qsh_verified = false
       end
 
       context = data['context']
@@ -100,7 +104,7 @@ module AtlassianJwtAuthentication
         account_id = data['sub']
       end
 
-      [jwt_auth, account_id, context]
+      [jwt_auth, account_id, context, qsh_verified]
     end
 
     private


### PR DESCRIPTION
In this pull-request I want to extend `atlassian-jwt-authentication` gem functionality of passing back to the application layer the status of `qsh` validation. It is needed for protecting application endpoints that shouldn't be called directly from the frontend.

What do you think about such approach? Companion pull-request: https://bitbucket.org/herocoders/clockwork/pull-requests/469/clk-1058-mandatory-qsh-validation-where