### PR TITLE
Update jwt dependency max version

### DIFF
--- a/atlassian_jwt_authentication_herocoders.gemspec
+++ b/atlassian_jwt_authentication_herocoders.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("addressable", ">= 2.4.0")
   s.add_dependency("faraday", ">= 0.11")
-  s.add_dependency("jwt", ">= 2.2.1")
+  s.add_dependency("jwt", ">= 2.2.1", "< 2.5.0")
 
   s.add_development_dependency("activerecord", ">= 4.1.0")
   s.add_development_dependency("bundler")


### PR DESCRIPTION
atlassian-jwt-authentication is using JWT::DefaultOptions which is not available in jwt 2.5.x version. Make this dep explicit.